### PR TITLE
Ensure security tests fail appropriately

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Tab indentation
+[*.java]
+indent_style = tab
+indent_size = 4

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
@@ -23,46 +23,40 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.reactive.context.ReactiveWebApplicationContext;
 import org.springframework.cloud.sample.bookstore.ServiceBrokerApplication;
 import org.springframework.cloud.sample.bookstore.web.model.Book;
 import org.springframework.cloud.sample.bookstore.web.model.BookStore;
+import org.springframework.cloud.sample.bookstore.web.model.User;
 import org.springframework.cloud.sample.bookstore.web.service.BookStoreService;
+import org.springframework.cloud.sample.bookstore.web.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.springframework.cloud.sample.bookstore.web.security.SecurityAuthorities.BOOK_STORE_ID_PREFIX;
 import static org.springframework.cloud.sample.bookstore.web.security.SecurityAuthorities.FULL_ACCESS;
 import static org.springframework.cloud.sample.bookstore.web.security.SecurityAuthorities.READ_ONLY;
+import static org.springframework.web.reactive.function.client.ExchangeFilterFunctions.basicAuthentication;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {ServiceBrokerApplication.class})
+@SpringBootTest(classes = {ServiceBrokerApplication.class, }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase
 public class BookStoreSecurityIntegrationTests {
 
 	private static final String BOOKSTORE_INSTANCE_ID = "1111-1111-1111-1111";
-
 	private static final String OTHER_INSTANCE_ID = "2222-2222-2222-2222";
-
-	@Autowired
-	private ReactiveWebApplicationContext context;
-
+	private String bookId;
+	private String bookStoreId;
 	@Autowired
 	private BookStoreService bookStoreService;
-
+	@Autowired
 	private WebTestClient client;
-
-	private String bookStoreId;
-
-	private String bookId;
+	@Autowired
+	private UserService userService;
 
 	@Before
 	public void setUp() {
-		this.client = WebTestClient.bindToApplicationContext(context)
-				.build();
 
 		BookStore bookStore = bookStoreService.createBookStore(BOOKSTORE_INSTANCE_ID);
 		bookStoreId = bookStore.getId();
@@ -70,99 +64,129 @@ public class BookStoreSecurityIntegrationTests {
 		Book book = bookStoreService.putBookInStore(bookStoreId,
 				new Book("978-1617292545", "Spring Boot in Action", "Craig Walls"));
 		bookId = book.getId();
+
 	}
 
 	@Test
 	public void anonymousAccessIsUnauthorized() throws Exception {
+
+		User dummyUser = new User("dummyuser", "dummypassword", "NO_AUTHORITY");
 		assertExpectedResponseStatus(
 				HttpStatus.UNAUTHORIZED,
 				HttpStatus.UNAUTHORIZED,
 				HttpStatus.UNAUTHORIZED,
-				HttpStatus.UNAUTHORIZED);
+				HttpStatus.UNAUTHORIZED,
+				dummyUser);
 	}
 
 	@Test
-	@WithMockUser(authorities = {FULL_ACCESS})
-	public void fullAccessWithoutInstanceIdIsAllowed() throws Exception {
-		assertExpectedResponseStatus(
-				HttpStatus.OK,
-				HttpStatus.OK,
-				HttpStatus.CREATED,
-				HttpStatus.OK);
-	}
-
-	@Test
-	@WithMockUser(authorities = {FULL_ACCESS, BOOK_STORE_ID_PREFIX + BOOKSTORE_INSTANCE_ID})
 	public void fullAccessWithInstanceIdIsAllowed() throws Exception {
+
+		User fullAccessUserWithInstanceId = userService
+				.createUser("fullAccessUserWithInstanceId", FULL_ACCESS, BOOK_STORE_ID_PREFIX + BOOKSTORE_INSTANCE_ID);
+
 		assertExpectedResponseStatus(
 				HttpStatus.OK,
 				HttpStatus.OK,
 				HttpStatus.CREATED,
-				HttpStatus.OK);
+				HttpStatus.OK,
+				fullAccessUserWithInstanceId);
 	}
 
 	@Test
-	@WithMockUser(authorities = {FULL_ACCESS, BOOK_STORE_ID_PREFIX + OTHER_INSTANCE_ID})
 	public void fullAccessWithOtherInstanceIdIsForbidden() throws Exception {
+		User fullAccessUserWithOtherId = userService
+				.createUser("fullAccessUserWithOtherId", FULL_ACCESS, BOOK_STORE_ID_PREFIX + OTHER_INSTANCE_ID);
+
 		assertExpectedResponseStatus(
 				HttpStatus.FORBIDDEN,
 				HttpStatus.FORBIDDEN,
 				HttpStatus.FORBIDDEN,
-				HttpStatus.FORBIDDEN);
+				HttpStatus.FORBIDDEN,
+				fullAccessUserWithOtherId);
 	}
 
 	@Test
-	@WithMockUser(authorities = {READ_ONLY})
-	public void readOnlyWithoutInstanceIdIsPartiallyAllowed() throws Exception {
+	public void fullAccessWithoutInstanceIdIsAllowed() throws Exception {
+		User fullAccessUser = userService.createUser("fullAccessUser", FULL_ACCESS);
+
 		assertExpectedResponseStatus(
 				HttpStatus.OK,
 				HttpStatus.OK,
-				HttpStatus.FORBIDDEN,
-				HttpStatus.FORBIDDEN);
+				HttpStatus.CREATED,
+				HttpStatus.OK,
+				fullAccessUser);
 	}
 
 	@Test
-	@WithMockUser(authorities = {READ_ONLY, BOOK_STORE_ID_PREFIX + BOOKSTORE_INSTANCE_ID})
 	public void readOnlyWithInstanceIdIsPartiallyAllowed() throws Exception {
+		User readOnlyUserwithInstanceId = userService
+				.createUser("readOnlyUserwithInstanceId", READ_ONLY, BOOK_STORE_ID_PREFIX + BOOKSTORE_INSTANCE_ID);
+
 		assertExpectedResponseStatus(
 				HttpStatus.OK,
 				HttpStatus.OK,
 				HttpStatus.FORBIDDEN,
-				HttpStatus.FORBIDDEN);
+				HttpStatus.FORBIDDEN,
+				readOnlyUserwithInstanceId);
 	}
 
 	@Test
-	@WithMockUser(authorities = {READ_ONLY, BOOK_STORE_ID_PREFIX + OTHER_INSTANCE_ID})
 	public void readOnlyWithOtherInstanceIdIsForbidden() throws Exception {
+		User readOnlyUserOtherInstanceId = userService
+				.createUser("readOnlyUserOtherInstanceId", READ_ONLY, BOOK_STORE_ID_PREFIX + OTHER_INSTANCE_ID);
+
 		assertExpectedResponseStatus(
 				HttpStatus.FORBIDDEN,
 				HttpStatus.FORBIDDEN,
 				HttpStatus.FORBIDDEN,
-				HttpStatus.FORBIDDEN);
+				HttpStatus.FORBIDDEN,
+				readOnlyUserOtherInstanceId);
 	}
 
-	private void assertExpectedResponseStatus(HttpStatus getAllStatus,
-											  HttpStatus getStatus,
-											  HttpStatus putStatus,
-											  HttpStatus deleteStatus) throws Exception {
-		this.client.get().uri("/bookstores/{bookStoreId}", bookStoreId)
+	@Test
+	public void readOnlyWithoutInstanceIdIsPartiallyAllowed() throws Exception {
+		User readonlyUserNoScope = userService.createUser("readonlyUserNoScope", READ_ONLY);
+
+		assertExpectedResponseStatus(
+				HttpStatus.OK,
+				HttpStatus.OK,
+				HttpStatus.FORBIDDEN,
+				HttpStatus.FORBIDDEN,
+				readonlyUserNoScope);
+	}
+
+
+	private void assertExpectedResponseStatus(HttpStatus getAllStatus, HttpStatus getStatus, HttpStatus putStatus,
+			HttpStatus deleteStatus, User user) {
+
+		WebTestClient authenticatedClient = this.client
+				.mutate()
+				.filter(basicAuthentication(user.getUsername(), user.getPassword()))
+				.build();
+
+		authenticatedClient
+				.get().uri("/bookstores/{bookStoreId}", bookStoreId)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isEqualTo(getAllStatus);
 
-		this.client.get().uri("/bookstores/{bookStoreId}/books/{bookId}", bookStoreId, bookId)
+		authenticatedClient
+				.get().uri("/bookstores/{bookStoreId}/books/{bookId}", bookStoreId, bookId)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isEqualTo(getStatus);
 
-		this.client.put().uri("/bookstores/{bookStoreId}/books", bookStoreId)
+		authenticatedClient
+				.put().uri("/bookstores/{bookStoreId}/books", bookStoreId)
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.syncBody("{\"isbn\":\"111-1111111111\", \"title\":\"test book\", \"author\":\"test author\"}")
 				.exchange()
 				.expectStatus().isEqualTo(putStatus);
 
-		this.client.delete().uri("/bookstores/{bookStoreId}/books/{bookId}", bookStoreId, bookId)
+		authenticatedClient
+				.delete().uri("/bookstores/{bookStoreId}/books/{bookId}", bookStoreId, bookId)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isEqualTo(deleteStatus);


### PR DESCRIPTION
Using a real instead of mocked webflux server in the security integration tests captures failure cases that do not occur when using a mock server
Create users in the the test database for every test