### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/ServiceBrokerApplication.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/ServiceBrokerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/config/SecurityConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/config/SecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServiceCatalogConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServiceCatalogConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServicesRepositoryConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServicesRepositoryConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ObjectToStringConverter.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ObjectToStringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceBinding.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceBinding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceInstance.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepository.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepository.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceBindingService.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceBindingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceService.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/config/MethodSecurityConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/config/MethodSecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/config/RepositoryConfiguration.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/config/RepositoryConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BaseController.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BaseController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookController.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookStoreController.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookStoreController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/ApplicationInformation.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/ApplicationInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/Book.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/BookStore.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/BookStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/User.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/model/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/BookStoreRepository.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/BookStoreRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/UserRepository.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResource.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResourceAssembler.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResource.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResourceAssembler.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/BookStorePermissionEvaluator.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/BookStorePermissionEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/RepositoryUserDetailsService.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/RepositoryUserDetailsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/SecurityAuthorities.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/SecurityAuthorities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/UserApplicationListener.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/security/UserApplicationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/service/BookStoreService.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/service/BookStoreService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/service/UserService.java
+++ b/webflux/src/main/java/org/springframework/cloud/sample/bookstore/web/service/UserService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/ApplicationTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfigurationTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepositoryTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepositoryTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceBindingServiceTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceBindingServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceServiceTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreIntegrationTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
+++ b/webflux/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/ServiceBrokerApplication.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/ServiceBrokerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/config/SecurityConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/config/SecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServiceCatalogConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServiceCatalogConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServicesRepositoryConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/config/ServicesRepositoryConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ObjectToStringConverter.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ObjectToStringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceBinding.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceBinding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceInstance.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/model/ServiceInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepository.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepository.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceBindingService.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceBindingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceService.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookStoreServiceInstanceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/config/BookstoreRepositoryConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/config/BookstoreRepositoryConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/config/MethodSecurityConfiguration.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/config/MethodSecurityConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BaseController.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BaseController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookController.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookStoreController.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/controller/BookStoreController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/ApplicationInformation.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/ApplicationInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/Book.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/BookStore.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/BookStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/User.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/model/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/BookStoreRepository.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/BookStoreRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/UserRepository.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/repository/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResource.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResourceAssembler.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResource.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResourceAssembler.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/resource/BookStoreResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/BookStorePermissionEvaluator.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/BookStorePermissionEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/RepositoryUserDetailsService.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/RepositoryUserDetailsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/SecurityAuthorities.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/SecurityAuthorities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/UserApplicationListener.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/security/UserApplicationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/service/BookStoreService.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/service/BookStoreService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/service/UserService.java
+++ b/webmvc/src/main/java/org/springframework/cloud/sample/bookstore/web/service/UserService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/ApplicationTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfigurationTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/config/ApplicationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepositoryTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceBindingRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepositoryTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/repository/ServiceInstanceRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceBindingServiceTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceBindingServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceServiceTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/servicebroker/service/BookstoreServiceInstanceServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreIntegrationTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
+++ b/webmvc/src/test/java/org/springframework/cloud/sample/bookstore/web/integration/BookStoreSecurityIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 83 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).