### PR TITLE
Resolve Issues with alpine docker and gradle config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ if (!project.hasProperty("dockerGroup")) {
 
 docker {
 	name "${dockerGroup}/bookstore-service-broker:${version}"
-	dockerfile file('../deploy/docker/Dockerfile')
+	dockerfile project.file('deploy/docker/Dockerfile')
 	files jar.archivePath
 	buildArgs(['JAR_FILE': "${jar.archiveName}"])
 }

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 VOLUME /tmp
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar


### PR DESCRIPTION
The embedded mongodb fails to be extracted correctly on alpine at container start up when deployed to k8s 1.21. 
There were a few issues in general on the web around embedded mongodb and alpine.
I changed to the standard jdk image and it worked fine. 

gradle config for docker task does not resolve the Dockerfile path correctly. I set it to use the project root as the starting path rather than ..